### PR TITLE
Fixes in xrandr timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Write down the `DEVPATH` and `DEVNAME` from the previous output, that's where UD
 $ udevadm info -n /dev/dri/card0
 $ udevadm info -q path -n /dev/dri/card0
 ```
-Create a new UDEV rule `/etc/udev/95-monitor-switch.rules`, replace _user_ with your Linux user:
+Create a new UDEV rule `/etc/udev/rules.d/95-monitor-switch.rules`, replace _user_ with your Linux user:
 ```
 ACTION=="change", KERNEL=="card0", SUBSYSTEM=="drm", ENV{DISPLAY}=":0", ENV{XAUTHORITY}="/home/user/.Xauthority", RUN+="/path/to/autorandr.sh"
 ```

--- a/autorandr.sh
+++ b/autorandr.sh
@@ -5,19 +5,26 @@ set -e
 logger -t autorandr "ACTION: $ACTION" # "change"
 logger -t autorandr "SUBSYSTEM: $SUBSYSTEM" # "drm"
 
-# BUG: xrandr doesn't see the new device unless is polling
-logger -t autorandr "Waiting for monitor configuration to change..."
-watch -g xrandr > /dev/null 2>&1
+# BUG: wait a bit before checking the config, the UDEV rule might run before the actual change -_-
+sleep 1
 
-EXTERNAL_MONITOR_STATUS=$( cat /sys/class/drm/card0-DP-1/status )
+# BUG: device on /sys/class/drm does not update without forcing an update with xrandr
+logger -t autorandr "Reading monitor configuration..."
+xrandr > /dev/null
+
+# change this to your external monitor device
+EXTERNAL_MONITOR=HDMI2
+EXTERNAL_MONITOR_STATUS=$( cat /sys/class/drm/card0-HDMI-A-2/status )
+
+echo "External monitor is: $EXTERNAL_MONITOR_STATUS"
 
 # Is the external monitor connected?
 if [ "$EXTERNAL_MONITOR_STATUS" = "connected" ]; then
     TYPE="double"
-    xrandr --output DP1 --mode 1920x1080 --pos 0x0 --rotate normal --output eDP1 --primary --mode 1920x1080 --pos 0x1080 --rotate normal
+    /usr/bin/xrandr --output $EXTERNAL_MONITOR --mode 1920x1080 --pos 0x0 --rotate normal --output eDP1 --primary --mode 1920x1080 --pos 0x1080 --rotate normal
 else
     TYPE="single"
-    /usr/bin/xrandr --output DP1 --off --output eDP1 --mode 1920x1080 --pos 0x0 --rotate normal
+    /usr/bin/xrandr --output $EXTERNAL_MONITOR --off --output eDP1 --mode 1920x1080 --pos 0x0 --rotate normal
 fi
 
 logger -t autorandr "Switched to $TYPE monitor mode"


### PR DESCRIPTION
This should fix a longstanding bug in managing the right timing when checking the monitor configuration.

Two bugs here:

1) checking the current monitor configuration _too fast_ will run autorandr before the monitor config has been updated, so I need to add a delay -_-

2) Checking `/sys/class/drm/xxxx/status` without running `xrandr` before seems to return an old value.